### PR TITLE
Add setting to disable Gogo anime scraping

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -508,3 +508,11 @@ msgstr ""
 msgctxt "#40372"
 msgid "Inspect Cloud Files on Scrape"
 msgstr ""
+
+msgctxt "#40373"
+msgid "Enable Gogo Scraping"
+msgstr ""
+
+msgctxt "#40374"
+msgid "Enable Source Scraping"
+msgstr ""

--- a/resources/language/resource.language.he_il/strings.po
+++ b/resources/language/resource.language.he_il/strings.po
@@ -508,3 +508,7 @@ msgstr ""
 msgctxt "#40372"
 msgid "Inspect Cloud Files on Scrape"
 msgstr ""
+
+msgctxt "#40374"
+msgid "Enable Source Scraping"
+msgstr ""

--- a/resources/lib/pages/__init__.py
+++ b/resources/lib/pages/__init__.py
@@ -86,9 +86,11 @@ class Sources(DisplayWindow):
         else:
             self.remainingProviders.remove('nyaa')
 
-        self.threads.append(
-            threading.Thread(target=self.gogo_worker, args=(anilist_id, episode, get_backup, rescrape,)))
-
+        if g.get_setting("general.enablegogo"):
+            self.threads.append(
+                threading.Thread(target=self.gogo_worker, args=(anilist_id, episode, get_backup, rescrape,)))
+        else:
+            self.remainingProviders.remove('gogo')
 ##        self.threads.append(
 ##            threading.Thread(target=self.animixplay_worker, args=(anilist_id, episode, get_backup, rescrape,)))
 

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -74,7 +74,7 @@
 		<setting id="general.dubsort" type="bool" label="40333" default="false" />
 
 		<!-- Enable/Disable Sources -->
-		<setting type="lsep" label="40334"/>
+		<setting type="lsep" label="40374"/>
 		<setting type="sep" />
 		<setting id="general.enablegogo" type="bool" label="40373" default="true" />
 	</category>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -72,6 +72,11 @@
 		<setting type="sep" />
 		<setting id="general.sortsources" type="enum" label="40332" values="Torrents|Embeds" default="0" />
 		<setting id="general.dubsort" type="bool" label="40333" default="false" />
+
+		<!-- Enable/Disable Sources -->
+		<setting type="lsep" label="40334"/>
+		<setting type="sep" />
+		<setting id="general.enablegogo" type="bool" label="40373" default="true" />
 	</category>
 
 	<!-- Accounts -->


### PR DESCRIPTION
For whatever reason, Gogo scraping always times out when I use it. I've added a setting to disable it, as it saves me a lot of time, personally.

To preserve functionality, Gogo is enabled by default still. You have to disable it to stop it.